### PR TITLE
Add FluentValidation for DTO validation

### DIFF
--- a/TooliRent.Application/TooliRent.Application.csproj
+++ b/TooliRent.Application/TooliRent.Application.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.0.1" />
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TooliRent.Application/Validation/AuthValidators.cs
+++ b/TooliRent.Application/Validation/AuthValidators.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+using TooliRent.Application.DTOs;
+
+namespace TooliRent.Application.Validation
+{
+    public sealed class RegisterDtoValidator : AbstractValidator<RegisterDto>
+    {
+        public RegisterDtoValidator()
+        {
+            RuleFor(x => x.Email).NotEmpty().EmailAddress();
+            RuleFor(x => x.Password).NotEmpty().MinimumLength(6);
+            RuleFor(x => x.DisplayName).NotEmpty().MaximumLength(100);
+        }
+    }
+
+    public sealed class LoginDtoValidator : AbstractValidator<LoginDto>
+    {
+        public LoginDtoValidator()
+        {
+            RuleFor(x => x.Email).NotEmpty().EmailAddress();
+            RuleFor(x => x.Password).NotEmpty();
+        }
+    }
+
+    public sealed class RefreshTokenDtoValidator : AbstractValidator<RefreshTokenDto>
+    {
+        public RefreshTokenDtoValidator()
+        {
+            RuleFor(x => x.RefreshToken).NotEmpty();
+        }
+    }
+}

--- a/TooliRent.Application/Validation/BookingValidators.cs
+++ b/TooliRent.Application/Validation/BookingValidators.cs
@@ -1,0 +1,35 @@
+using FluentValidation;
+using TooliRent.Application.DTOs;
+
+namespace TooliRent.Application.Validation
+{
+    public sealed class BookingItemCreateDtoValidator : AbstractValidator<BookingItemCreateDto>
+    {
+        public BookingItemCreateDtoValidator()
+        {
+            RuleFor(x => x.ToolId).GreaterThan(0);
+            RuleFor(x => x.Quantity).GreaterThan(0);
+        }
+    }
+
+    public sealed class CreateBookingDtoValidator : AbstractValidator<CreateBookingDto>
+    {
+        public CreateBookingDtoValidator()
+        {
+            RuleFor(x => x.StartDate).NotEmpty();
+            RuleFor(x => x.EndDate).NotEmpty();
+            RuleFor(x => x).Must(x => x.StartDate.Date < x.EndDate.Date)
+                .WithMessage("StartDate must be before EndDate.");
+
+            RuleFor(x => x.Items)
+                .NotNull().WithMessage("Items are required.")
+                .NotEmpty().WithMessage("At least one item is required.");
+
+            RuleForEach(x => x.Items).SetValidator(new BookingItemCreateDtoValidator());
+
+            RuleFor(x => x.Items)
+                .Must(items => items.Select(i => i.ToolId).Distinct().Count() == items.Count)
+                .WithMessage("Duplicate tools are not allowed in a booking.");
+        }
+    }
+}

--- a/TooliRent.Application/Validation/ToolCategoryValidators.cs
+++ b/TooliRent.Application/Validation/ToolCategoryValidators.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using TooliRent.Application.DTOs;
+
+namespace TooliRent.Application.Validation
+{
+    public sealed class ToolCategoryCreateDtoValidator : AbstractValidator<ToolCategoryCreateDto>
+    {
+        public ToolCategoryCreateDtoValidator()
+        {
+            RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
+            RuleFor(x => x.Description).MaximumLength(500);
+        }
+    }
+
+    public sealed class ToolCategoryUpdateDtoValidator : AbstractValidator<ToolCategoryUpdateDto>
+    {
+        public ToolCategoryUpdateDtoValidator()
+        {
+            RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
+            RuleFor(x => x.Description).MaximumLength(500);
+        }
+    }
+}

--- a/TooliRent.Application/Validation/ToolValidators.cs
+++ b/TooliRent.Application/Validation/ToolValidators.cs
@@ -1,0 +1,36 @@
+﻿using FluentValidation;
+using TooliRent.Application.DTOs;
+using TooliRent.Domain.Enums;
+
+namespace TooliRent.Application.Validation
+{
+    public sealed class ToolCreateDtoValidator : AbstractValidator<ToolCreateDto>
+    {
+        public ToolCreateDtoValidator()
+        {
+            RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
+            RuleFor(x => x.Description).NotEmpty().MaximumLength(500);
+            RuleFor(x => x.PricePerDay).InclusiveBetween(0m, 100000m)
+                .PrecisionScale(18, 2, false)
+                .WithMessage("Price per day may have at most 2 decimal.");
+            RuleFor(x => x.QuantityAvailable).GreaterThanOrEqualTo(0);
+            RuleFor(x => x.CategoryId).GreaterThan(0);
+        }
+    }
+
+    public sealed class ToolUpdateDtoValidator : AbstractValidator<ToolUpdateDto>
+    {
+        public ToolUpdateDtoValidator()
+        {
+            RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
+            RuleFor(x => x.Description).NotEmpty().MaximumLength(500);
+            RuleFor(x => x.PricePerDay).InclusiveBetween(0m, 100000m)
+                .PrecisionScale(18, 2, false)
+                .WithMessage("Price per day may have at most 2 decimal.");
+            RuleFor(x => x.QuantityAvailable).GreaterThanOrEqualTo(0);
+            RuleFor(x => x.CategoryId).GreaterThan(0);
+            RuleFor(x => x.Status).Must(v => Enum.IsDefined(typeof(ToolStatus), v))
+                .WithMessage("Status must be valid");
+        }
+    }
+}

--- a/TooliRent.WebApi/Program.cs
+++ b/TooliRent.WebApi/Program.cs
@@ -12,6 +12,10 @@ using TooliRent.Application.Services;
 using TooliRent.Domain.Interfaces;
 using TooliRent.Infrastructure.Repositories;
 using TooliRent.Application.Mapping;
+using FluentValidation;
+using FluentValidation.AspNetCore;
+using TooliRent.Application.DTOs;
+using TooliRent.Application.Validation;
 
 namespace TooliRent.WebApi
 {
@@ -107,6 +111,10 @@ namespace TooliRent.WebApi
 
             builder.Services.AddScoped<IAdminService, AdminService>();
             builder.Services.AddScoped<IAdminRepository, AdminRepository>();
+
+            // Fluent validator
+            builder.Services.AddFluentValidationAutoValidation(o => o.DisableDataAnnotationsValidation = true);
+            builder.Services.AddValidatorsFromAssembly(typeof(Application.Validation.BookingItemCreateDtoValidator).Assembly);
 
             var app = builder.Build();
 

--- a/TooliRent.WebApi/TooliRent.WebApi.csproj
+++ b/TooliRent.WebApi/TooliRent.WebApi.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.20" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.20">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Updated the project to include FluentValidation for validating various DTOs. Implemented validators for `RegisterDto`, `LoginDto`, `RefreshTokenDto`, `BookingItemCreateDto`, `CreateBookingDto`, `ToolCategoryCreateDto`, `ToolCategoryUpdateDto`, `ToolCreateDto`, and `ToolUpdateDto`. Enforced rules for required fields, length constraints, and value ranges. Modified `Program.cs` to register FluentValidation services for automatic request validation.