### PR TITLE
Refactor enums in DTOs and update JSON serialization

### DIFF
--- a/TooliRent.Application/DTOs/BookingDtos.cs
+++ b/TooliRent.Application/DTOs/BookingDtos.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using TooliRent.Domain.Enums;
 
 namespace TooliRent.Application.DTOs
 {
@@ -37,7 +38,7 @@ namespace TooliRent.Application.DTOs
         public int ToolId { get; set; }
         public string ToolName { get; set; } = string.Empty;
         public int Quantity { get; set; }
-        public int Status { get; set; }
+        public BookingItemStatus Status { get; set; }
     }
 
     public sealed class BookingDetailDto

--- a/TooliRent.Application/DTOs/ToolDtos.cs
+++ b/TooliRent.Application/DTOs/ToolDtos.cs
@@ -1,5 +1,5 @@
-using System;
 using System.ComponentModel.DataAnnotations;
+using TooliRent.Domain.Enums;
 
 namespace TooliRent.Application.DTOs
 {
@@ -11,7 +11,7 @@ namespace TooliRent.Application.DTOs
         public int QuantityAvailable { get; set; }
         public int CategoryId { get; set; }
         public string CategoryName { get; set; } = string.Empty;
-        public int Status { get; set; }
+        public ToolStatus Status { get; set; }
     }
 
     public sealed class ToolDetailDto
@@ -23,7 +23,7 @@ namespace TooliRent.Application.DTOs
         public int QuantityAvailable { get; set; }
         public int CategoryId { get; set; }
         public string CategoryName { get; set; } = string.Empty;
-        public int Status { get; set; }
+        public ToolStatus Status { get; set; }
         public DateTime CreatedAt { get; set; }
     }
 
@@ -53,7 +53,6 @@ namespace TooliRent.Application.DTOs
         public int QuantityAvailable { get; set; }
         [Range(1, int.MaxValue)]
         public int CategoryId { get; set; }
-        [Range(0, 4)] // ToolStatus enum range
-        public int Status { get; set; }
+        public ToolStatus Status { get; set; }
     }
 }

--- a/TooliRent.Application/Mapping/ToolProfile.cs
+++ b/TooliRent.Application/Mapping/ToolProfile.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using System.Net;
 using TooliRent.Application.DTOs;
 using TooliRent.Domain.Entities;
 using TooliRent.Domain.Enums;
@@ -10,11 +11,11 @@ namespace TooliRent.Application.Mapping
         public ToolProfile()
         {
             CreateMap<Tool, ToolListItemDto>()
-                .ForMember(dest => dest.CategoryName, opt => opt.MapFrom(src => src.Category))
+                .ForMember(dest => dest.CategoryName, opt => opt.MapFrom(src => src.Category != null ? src.Category.Name : string.Empty))
                 .ForMember(dest => dest.Status, opt => opt.MapFrom(src => (int)src.Status));
 
             CreateMap<Tool, ToolDetailDto>()
-                .ForMember(dest => dest.CategoryName, opt => opt.MapFrom(src => src.Category))
+                .ForMember(dest => dest.CategoryName, opt => opt.MapFrom(src => src.Category != null ? src.Category.Name : string.Empty))
                 .ForMember(dest => dest.Status, opt => opt.MapFrom(src => (int)src.Status));
 
             CreateMap<ToolCreateDto, Tool>()
@@ -27,7 +28,6 @@ namespace TooliRent.Application.Mapping
             CreateMap<ToolUpdateDto, Tool>()
                 .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name.Trim()))
                 .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description.Trim()))
-                .ForMember(dest => dest.Status, opt => opt.MapFrom(src => (ToolStatus)src.Status))
                 .ForMember(dest => dest.Category, opt => opt.Ignore())
                 .ForMember(dest => dest.CreatedAt, opt => opt.Ignore());
         }

--- a/TooliRent.WebApi/Program.cs
+++ b/TooliRent.WebApi/Program.cs
@@ -16,6 +16,7 @@ using FluentValidation;
 using FluentValidation.AspNetCore;
 using TooliRent.Application.DTOs;
 using TooliRent.Application.Validation;
+using System.Text.Json.Serialization;
 
 namespace TooliRent.WebApi
 {
@@ -30,7 +31,11 @@ namespace TooliRent.WebApi
                 options.UseSqlServer(
                     builder.Configuration.GetConnectionString("DefaultConnection")));
 
-            builder.Services.AddControllers();
+            builder.Services.AddControllers()
+                .AddJsonOptions(o =>
+                {
+                    o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                });
             
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen(opt =>


### PR DESCRIPTION
- Updated `BookingDtos.cs` to use `BookingItemStatus` enum for the `Status` property in `BookingItemDto`.
- Changed `Status` properties in `ToolDtos.cs` to use `ToolStatus` enum instead of integers for `ToolListItemDto` and `ToolDetailDto`.
- Modified mapping configurations in `ToolProfile.cs` to directly map the new enum types.
- Enhanced `Program.cs` to include JSON serialization options for converting enum values to strings in API responses.